### PR TITLE
inline-block ie7 hack

### DIFF
--- a/css/bootstrap-ie7.css
+++ b/css/bootstrap-ie7.css
@@ -14,6 +14,7 @@ input[type="radio"],input[type="checkbox"]{margin-top:0}
 .list-group{margin-left:0}
 ul .list-group-item{list-style:none}
 .sr-only{clip:rect(0 0 0 0)}
+.list-inline > li {display:inline;zoom:1;}
 .glyphicon{text-decoration:inherit;line-height:normal}
 .glyphicon-adjust{zoom:expression(this.runtimeStyle['zoom']='1',this.innerHTML='&#xe063;')}
 .glyphicon-align-center{zoom:expression(this.runtimeStyle['zoom']='1',this.innerHTML='&#xe053;')}


### PR DESCRIPTION
Typical IE7 hack for [.list-inline](http://getbootstrap.com/css/#type-lists)
