### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Bootstrap 3 for IE7
+# Bootstrap 3 for IE7
 
 [![Join the chat at https://gitter.im/coliff/bootstrap-ie7](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/coliff/bootstrap-ie7?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
